### PR TITLE
fix termination procedure for receiving context

### DIFF
--- a/index.html
+++ b/index.html
@@ -1712,7 +1712,7 @@
             When the <code>terminate()</code> method is called on a
             <a>PresentationConnection</a> <var>S</var> in a <a>receiving
             browsing context</a>, the <a>user agent</a> MUST run the algorithm
-            to <a>terminate a presentation in a controlling browsing
+            to <a>terminate a presentation in a receiving browsing
             context</a> using <var>S</var>.
           </p>
           <p>


### PR DESCRIPTION
use the termination procedure in receiving browsing context while calling terminate() in receiver page.
